### PR TITLE
Added value to the type mismatch exception for further tracing

### DIFF
--- a/src/AutopilotField.php
+++ b/src/AutopilotField.php
@@ -233,7 +233,7 @@ class AutopilotField
 
         // type of field is set in the constructor
         if (($this->getType() !== $type) && !is_null($value)) {
-            throw TypeMisMatchException::create($this->getName(), $this->getType(), $type);
+            throw TypeMisMatchException::create($this->getName(), $this->getType(), $type, $value);
         }
 
         return $this->value = $value;

--- a/src/Exceptions/TypeMisMatchException.php
+++ b/src/Exceptions/TypeMisMatchException.php
@@ -6,13 +6,14 @@ use Exception;
 
 class TypeMisMatchException extends Exception
 {
-    public static function create(string $field, string $expected, ?string $type = null): self
+    public static function create(string $field, string $expected, ?string $type = null, ?string $value = null): self
     {
         return new static(sprintf(
-            'Type value mismatch! Expected: %s%s on field %s',
+            'Type value mismatch! Expected: %s%s on field %s with value %s',
             $expected,
             (is_null($type) ? '' : ', got: ' . $type),
-            $field
+            $field,
+            $value
         ));
     }
 }


### PR DESCRIPTION
Deze PR voegt een extra parameter toe aan de `TypeMisMatchException` exception. Het is nu namelijk nog niet helemaal duidelijk wat er fout gaat.

https://sentry.io/organizations/zonneplan/issues/2061174048/?project=105836&query=is%3Aunresolved&statsPeriod=14d